### PR TITLE
Quick workaround for TypeError: unsupported operand type(s) for +: da…

### DIFF
--- a/redis_elector.py
+++ b/redis_elector.py
@@ -29,7 +29,7 @@ zk_hosts = os.getenv('zk_hosts', "zookeeper:2181")
 zk_path_to_master = zk_base + "/master"
 
 def logger(msg):
-    print datetime.datetime.now() + ": " + msg
+    print datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + ": " + msg
     sys.stdout.flush()
 
 def signal_handler(signal, frame):


### PR DESCRIPTION
Hi, 

Recently i gave your redis_elector.py a try and ran into the following error: 

```
    print datetime.datetime.now() + ": " + msg
TypeError: unsupported operand type(s) for +: 'datetime.datetime' and 'str'
```

Added a quick fix to get stuff working. 

I also have some more example .aurora files with templates and pex usage examples in case your interested. 
